### PR TITLE
make non-empty _STR readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "bntx"
 version = "0.1.0"
-source = "git+https://github.com/ScanMountGoat/bntx?rev=73fe278#73fe278fdbad69a0358e8bf65a0555f06fb8ac1b"
+source = "git+https://github.com/azel-s/bntx#3f7392fac902066cafdda1426503f4c0b81e17f6"
 dependencies = [
  "binrw 0.11.2",
  "ddsfile",

--- a/ultimate_tex/Cargo.toml
+++ b/ultimate_tex/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 nutexb = { git = "https://github.com/jam1garner/nutexb", features = ["ddsfile"] }
-bntx = { git = "https://github.com/ScanMountGoat/bntx", rev = "73fe278" }
+bntx = { git = "https://github.com/azel-s/bntx" }
 image_dds = { git = "https://github.com/ScanMountGoat/image_dds", rev = "6debc74" }
 strum = { version = "0.24", features = ["derive"] }


### PR DESCRIPTION
Added a `+ 1` to the `len `attribute for `BntxStr`.

Not sure if this is the proper way to fix this, but force reading the string terminator `\0` seems to fix it (without breaking vanilla files).